### PR TITLE
Changed the issue for requirements.txt file

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ Jinja2==2.10
 jmespath==0.9.4
 MarkupSafe==1.1.1
 numpy==1.16.2
-pkg-resources==0.0.0
+#pkg-resources==0.0.0
 python-dateutil==2.8.0
 requests==2.21.0
 s3transfer==0.2.0


### PR DESCRIPTION
See [StackOverflow](https://stackoverflow.com/questions/38992194/why-does-pip-freeze-list-pkg-resources-0-0-0/41300675)